### PR TITLE
KLIP calibration of visibilities and closure phases

### DIFF
--- a/fouriever/intercorr.py
+++ b/fouriever/intercorr.py
@@ -9,6 +9,7 @@ import astropy.io.fits as pyfits
 import matplotlib.pyplot as plt
 import numpy as np
 
+import glob
 import os
 import sys
 
@@ -31,13 +32,20 @@ class data():
         ----------
         idir: str
             Input directory where fits files are located.
-        fitsfiles: list of str
-            List of fits files which shall be opened.
+        fitsfiles: list of str, None
+            List of fits files which shall be opened. All fits files
+            from ``idir`` are opened with ``fitsfiles=None``.
         """
         
         self.idir = idir
         self.fitsfiles = fitsfiles
-        
+
+        if self.fitsfiles is None:
+            self.fitsfiles = glob.glob(self.idir+'*fits')
+            for i, item in enumerate(self.fitsfiles):
+                head, tail = os.path.split(item)
+                self.fitsfiles[i] = tail
+
         self.inst_list = []
         self.data_list = []
         for i in range(len(self.fitsfiles)):
@@ -46,7 +54,7 @@ class data():
                                              verbose=False)
             self.inst_list += inst_list
             self.data_list += data_list
-        
+
         self.set_inst(inst=self.inst_list[0])
         self.set_observables(self.get_observables())
         

--- a/fouriever/uvfit.py
+++ b/fouriever/uvfit.py
@@ -11,6 +11,9 @@ import numpy as np
 
 import emcee
 from scipy.optimize import minimize
+
+import glob
+import os
 import sys
 
 from . import inst
@@ -38,9 +41,16 @@ class data():
         ----------
         idir: str
             Input directory where fits files are located.
-        fitsfiles: list of str
-            List of fits files which shall be opened.
+        fitsfiles: list of str, None
+            List of fits files which shall be opened. All fits files
+            from ``idir`` are opened with ``fitsfiles=None``.
         """
+        
+        if fitsfiles is None:
+            fitsfiles = glob.glob(idir+'*fits')
+            for i, item in enumerate(fitsfiles):
+                head, tail = os.path.split(item)
+                fitsfiles[i] = tail
         
         self.inst_list = []
         self.data_list = []


### PR DESCRIPTION
Hi @kammerje,

I have been looking into the KLIP calibration of the visibilities and closure phases of a SPHERE/SAM dataset. I simply added an `if` statement in the `project` method, check the content of the FITS files for the `OI_VIS2` and `OI_T3` extensions, and follow your implementation for kernel phase.

It runs but please check on your earliest convenience. I was in particular not sure about what to do with `VIS2ERR` and `T3PHIERR`. I saw that the kernel phase uncertainties (`KP-SIGM`?) are projected onto the principal components but I wasn't sure if this can be done with the V2 and CP uncertainties?

I was also expecting that after the projection of the science data on the calibration components this would get subtracted from the science data, but that does not seem to be needed with the kernel phase at least? Sorry if I have misunderstood how this works... Your feedback is very welcome 😊.

For the 2018 epoch of HD 142527, I get currently a higher chi2 when using `K_klip=10` (right) compared to using the regular calibration (left). Probably there is still an issue, e.g. related to the uncertainties.
<img width="1082" alt="sphere_sam" src="https://user-images.githubusercontent.com/3204762/153905348-c1ada9da-d44e-4c8d-a720-b4d54bb9908d.png">

I also made a slight update with the functions that read in FITS files. Whenever the argument for the filenames is set to `None`, it simply reads in all the FITS files in the directory that is given as input. For example, setting the directory of `idir` in `uvfit` together with `fitsfiles=None`.

Let me know what you think and feel free to make changes directly to this branch.