### PR TITLE
Nested sampling with MultiNest

### DIFF
--- a/fouriever/plot.py
+++ b/fouriever/plot.py
@@ -690,23 +690,23 @@ def chi2map(pps_unique,
     plt.close()
 
 def chains(fit,
-           sampler,
+           samples,
            ofile=None):
     """
     Parameters
     ----------
     fit: dict
         Model fit whose MCMC chains shall be plotted.
-    sampler: array
-        Sampler of MCMC.
+    samples: array
+        Posterior samples.
     ofile: str
         Path under which figures shall be saved.
     """
     
     if (fit['model'] == 'ud'):
         fig = plt.figure()
-        plt.plot(sampler.flatchain[:, 0], color=datacol)
-        plt.axhline(np.percentile(sampler.flatchain[:, 0], 50.), color=modelcol, label='MCMC median')
+        plt.plot(samples[:, 0], color=datacol)
+        plt.axhline(np.percentile(samples[:, 0], 50.), color=modelcol, label='MCMC median')
         plt.axhline(fit['p'][0], ls='--', color=gridcol, label='Initial guess')
         plt.xlabel('Step')
         plt.ylabel('$\\theta$ [mas]')
@@ -723,13 +723,13 @@ def chains(fit,
         plt.close()
     elif (fit['model'] == 'bin'):
         ylabels = ['$f$ [%]', '$\\rho$ [mas]', '$\\varphi$ [deg]']
-        rho = np.sqrt(sampler.flatchain[:, 1]**2+sampler.flatchain[:, 2]**2)
+        rho = np.sqrt(samples[:, 1]**2+samples[:, 2]**2)
         rho0 = np.sqrt(fit['p'][1]**2+fit['p'][2]**2)
-        phi = np.rad2deg(np.arctan2(sampler.flatchain[:, 1], sampler.flatchain[:, 2]))
+        phi = np.rad2deg(np.arctan2(samples[:, 1], samples[:, 2]))
         phi0 = np.rad2deg(np.arctan2(fit['p'][1], fit['p'][2]))
         fig, ax = plt.subplots(len(fit['p']), 1, sharex='col', figsize=(6.4, 1.6*len(fit['p'])))
-        ax[0].plot(sampler.flatchain[:, 0]*100., color=datacol)
-        ax[0].axhline(np.percentile(sampler.flatchain[:, 0], 50.)*100., color=modelcol, label='MCMC median')
+        ax[0].plot(samples[:, 0]*100., color=datacol)
+        ax[0].axhline(np.percentile(samples[:, 0], 50.)*100., color=modelcol, label='MCMC median')
         ax[0].axhline(fit['p'][0]*100., ls='--', color=gridcol, label='Initial guess')
         ax[1].plot(rho, color=datacol)
         ax[1].axhline(np.percentile(rho, 50.), color=modelcol)
@@ -756,13 +756,13 @@ def chains(fit,
         plt.close()
     else:
         ylabels = ['$f$ [%]', '$\\rho$ [mas]', '$\\varphi$ [deg]', '$\\theta$ [mas]']
-        rho = np.sqrt(sampler.flatchain[:, 1]**2+sampler.flatchain[:, 2]**2)
+        rho = np.sqrt(samples[:, 1]**2+samples[:, 2]**2)
         rho0 = np.sqrt(fit['p'][1]**2+fit['p'][2]**2)
-        phi = np.rad2deg(np.arctan2(sampler.flatchain[:, 1], sampler.flatchain[:, 2]))
+        phi = np.rad2deg(np.arctan2(samples[:, 1], samples[:, 2]))
         phi0 = np.rad2deg(np.arctan2(fit['p'][1], fit['p'][2]))
         fig, ax = plt.subplots(len(fit['p']), 1, sharex='col', figsize=(6.4, 1.6*len(fit['p'])))
-        ax[0].plot(sampler.flatchain[:, 0]*100., color=datacol)
-        ax[0].axhline(np.percentile(sampler.flatchain[:, 0], 50.)*100., color=modelcol, label='MCMC median')
+        ax[0].plot(samples[:, 0]*100., color=datacol)
+        ax[0].axhline(np.percentile(samples[:, 0], 50.)*100., color=modelcol, label='MCMC median')
         ax[0].axhline(fit['p'][0]*100., ls='--', color=gridcol, label='Initial guess')
         ax[1].plot(rho, color=datacol)
         ax[1].axhline(np.percentile(rho, 50.), color=modelcol)
@@ -770,8 +770,8 @@ def chains(fit,
         ax[2].plot(phi, color=datacol)
         ax[2].axhline(np.percentile(phi, 50.), color=modelcol)
         ax[2].axhline(phi0, ls='--', color=gridcol)
-        ax[3].plot(sampler.flatchain[:, 3], color=datacol)
-        ax[3].axhline(np.percentile(sampler.flatchain[:, 3], 50.), color=modelcol)
+        ax[3].plot(samples[:, 3], color=datacol)
+        ax[3].axhline(np.percentile(samples[:, 3], 50.), color=modelcol)
         ax[3].axhline(fit['p'][3], ls='--', color=gridcol)
         plt.xlabel('Step')
         for i in range(len(fit['p'])):
@@ -792,21 +792,21 @@ def chains(fit,
         plt.close()
 
 def corner(fit,
-           sampler,
+           samples,
            ofile=None):
     """
     Parameters
     ----------
     fit: dict
         Model fit whose posterior distribution shall be plotted.
-    sampler: array
-        Sampler of MCMC.
+    samples: array
+        Posterior samples.
     ofile: str
         Path under which figures shall be saved.
     """
     
     if (fit['model'] == 'ud'):
-        fig = cp.corner(sampler.flatchain,
+        fig = cp.corner(samples,
                         labels=[r'$\theta$ [mas]'],
                         titles=[r'$\theta$'],
                         quantiles=[0.16, 0.5, 0.84],
@@ -822,10 +822,10 @@ def corner(fit,
         # plt.show()
         plt.close()
     elif (fit['model'] == 'bin'):
-        temp = sampler.flatchain.copy()
+        temp = samples.copy()
         temp[:, 0] *= 100.
-        temp[:, 1] = np.sqrt(sampler.flatchain[:, 1]**2+sampler.flatchain[:, 2]**2)
-        temp[:, 2] = np.rad2deg(np.arctan2(sampler.flatchain[:, 1], sampler.flatchain[:, 2]))
+        temp[:, 1] = np.sqrt(samples[:, 1]**2+samples[:, 2]**2)
+        temp[:, 2] = np.rad2deg(np.arctan2(samples[:, 1], samples[:, 2]))
         fig = cp.corner(temp,
                         labels=[r'$f$ [%]', r'$\rho$ [mas]', r'$\varphi$ [deg]'],
                         titles=[r'$f$', r'$\rho$', r'$\varphi$'],
@@ -842,10 +842,10 @@ def corner(fit,
         # plt.show()
         plt.close()
     else:
-        temp = sampler.flatchain.copy()
+        temp = samples.copy()
         temp[:, 0] *= 100.
-        temp[:, 1] = np.sqrt(sampler.flatchain[:, 1]**2+sampler.flatchain[:, 2]**2)
-        temp[:, 2] = np.rad2deg(np.arctan2(sampler.flatchain[:, 1], sampler.flatchain[:, 2]))
+        temp[:, 1] = np.sqrt(samples[:, 1]**2+samples[:, 2]**2)
+        temp[:, 2] = np.rad2deg(np.arctan2(samples[:, 1], samples[:, 2]))
         fig = cp.corner(temp,
                         labels=[r'$f$ [%]', r'$\rho$ [mas]', r'$\varphi$ [deg]', r'$\theta$ [mas]'],
                         titles=[r'$f$', r'$\rho$', r'$\varphi$', r'$\theta$'],

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ install_requires =
     astropy
     corner
     emcee
+    pymultinest
 
 [options.extras_require]
 fft =


### PR DESCRIPTION
Hi @kammerje,

This pull request adds support for using the nested sampling algorithm of `MultiNest`. The `mcmc` function takes the additional parameters `sampler` (default: emcee) and `n_live_points`. Multiprocessing is supported through `mpi4py`.

The `chains` and `corner` plot functions receive the samples now directly as input, instead of the `emcee` sampler object. The `chains` plot is skipped when `sampler='multinest'`.

The prior boundaries are set to an arbitrary range of 20% from the best-fit value from the `chi2map`, so that is quite arbitrary and could perhaps be changed.

I have also included the sampler name, the array with samples, and the ln(z), to the dictionary that is returned by `mcmc`.

Let me know if you have any feedback!