### PR TITLE
Method for estimating the phases from the closure phases

### DIFF
--- a/fouriever/uvfit.py
+++ b/fouriever/uvfit.py
@@ -2253,9 +2253,10 @@ class data():
             v_list.append(v_coord)
 
         if ofile is not None:
-            # Plot the arrow to the provided companion parameters
-            plt.arrow(0., 0., u_comp, v_comp, head_width=1., head_length=1.,
-                      ls='-', lw=0.7, capstyle='round', facecolor='black')
+            if fit is not None:
+                # Plot the arrow to the provided companion parameters
+                plt.arrow(0., 0., u_comp, v_comp, head_width=1., head_length=1.,
+                          ls='-', lw=0.7, capstyle='round', facecolor='black')
 
             # Update the axes labels and ticks
             plt.xlabel('$u$ (arcsec$^{-1}$)', fontsize=12., labelpad=0.25)


### PR DESCRIPTION
Hi @kammerje,

As discussed, this PR implements the `estimate_phase` method in the `data` class. It estimates the phases from the closure phases by inverting the phase-to-CP matrix (i.e. `cpmat`) and projecting the closure phases on this conversion matrix.

The phases are returned as array together with the u-v coordinates and a plot is created of the phases. The latter can optionally include an arrow in the direction of an actual companion, for example the best-fit parameters determined with `chi2map`, and the associated model phases in the background.

Let me know in case you have any feedback!