### PR TITLE
Fix for prior_bounds with multiple wavelengths and several small updates

### DIFF
--- a/fouriever/plot.py
+++ b/fouriever/plot.py
@@ -730,6 +730,8 @@ def chi2map(pps_unique,
     # plt.show()
     plt.close()
 
+    return chi2s_rbf, grid_ra_dec_fine
+
 def chains(fit,
            samples,
            ofile=None):


### PR DESCRIPTION
Hi @kammerje,

This PR fixes an issue with the `prior_bounds` in `mcmc` that is needed for the nested sampling. It only worked for fitting a single wavelength/contrast, but I have generalized to multiple wavelengths.

I also added a few minor things:

- Minimum and maximum baseline are printed by the `data` methods.
- The corner plot is skipped when `ofile=None`. It may crash otherwise (depending on memory) when fitting many wavelengths simultaneously.
- Added ERIS to the list of instruments for which output is printed.
- Added the `nwalkers` parameter to the `mcmc` method. The default is set to `None`, which behaves as before.
- Added `chi2_map`, `chi2_grid`, and `nsigma_map` to the output dictionary of `chi2map`

Let me know in case you have any feedback and/or want any of these features not to be included!