### PR TITLE
Added use_mpmath parameter to chi2map and nsigma

### DIFF
--- a/fouriever/util.py
+++ b/fouriever/util.py
@@ -898,8 +898,6 @@ def nsigma(chi2r_test,
         Log-probability of a binary detection.
     """
 
-    num_limit = False
-
     if not use_mpmath:
         bin_prob = stats.chi2.cdf(ndof*chi2r_test/chi2r_true, ndof)
         log_bin_prob = np.log10(bin_prob)

--- a/fouriever/util.py
+++ b/fouriever/util.py
@@ -5,12 +5,13 @@ from __future__ import division
 # IMPORTS
 # =============================================================================
 
-import astropy.io.fits as pyfits
-import matplotlib.pyplot as plt
+import mpmath
 import numpy as np
 
+from scipy import stats
+from scipy.interpolate import interp1d
 from scipy.special import j1
-import scipy.stats as stats
+
 
 rad2mas = 180./np.pi*3600.*1000. # convert rad to mas
 mas2rad = np.pi/180./3600./1000. # convert mas to rad
@@ -866,8 +867,12 @@ def chi2_ud_bin_fitdiamonly(theta0,
 
 def nsigma(chi2r_test,
            chi2r_true,
-           ndof):
+           ndof,
+           use_mpmath=False):
     """
+    Function for calculating the confidence level as
+    defined in Eq. 1 of Absil et al. (2011).
+
     Parameters
     ----------
     chi2r_test: float
@@ -876,31 +881,55 @@ def nsigma(chi2r_test,
         Reduced chi-squared of true model.
     ndof: int
         Number of degrees of freedom.
-    
+    use_mpmath: bool
+        Use the ``mpmath`` module for enabling a higher precision
+        (50 decimals) on the calculated value from the CDF of the
+        chi2 distribution. If set to ``False``, the ``chi2``
+        function from ``scipy`` is used. The confidence level is
+        always calculated with ``scipy`` and has a maximum value
+        of approximately 8 sigma. The default argument is set to
+        ``False``.
+
     Returns
     -------
     nsigma: float
         Detection significance.
+    log_bin_prob: float
+        Log-probability of a binary detection.
     """
-    
-    q = stats.chi2.cdf(ndof*chi2r_test/chi2r_true, ndof)
-    p = 1.-q
-    nsigma = np.sqrt(stats.chi2.ppf(1.-p, 1.))
-    if (p < 1e-15):
+
+    num_limit = False
+
+    if not use_mpmath:
+        bin_prob = stats.chi2.cdf(ndof*chi2r_test/chi2r_true, ndof)
+        log_bin_prob = np.log10(bin_prob)
+
+    else:
+        # Decimal digits of precision
+        mpmath.mp.dps = 50
+
+        def chi2_cdf(x, k): 
+            x, k = mpmath.mpf(x), mpmath.mpf(k) 
+            return mpmath.gammainc(k/2, 0, x/2, regularized=True)
+
+        bin_prob = chi2_cdf(ndof*chi2r_test/chi2r_true, float(ndof))
+        log_bin_prob = float(mpmath.log10(bin_prob))
+        bin_prob = float(bin_prob)
+
+    nsigma = np.sqrt(stats.chi2.ppf(bin_prob, 1.))
+    if (bin_prob > 1.-1e-15):
         nsigma = np.sqrt(stats.chi2.ppf(1.-1e-15, 1.))
-    
-    return nsigma
-    
+
+    return nsigma, log_bin_prob
+
     # THIS IS WRONG (CF. CANDID)
-    p = stats.chi2.cdf(ndof, ndof*chi2r_test/chi2r_true)
-    log10p = np.log10(max(p, 10**(-155.623))) # 50 sigma max.
-    nsigma = np.sqrt(stats.chi2.ppf(1.-p, 1.))
-    
-#    c = np.array([-0.25028407, 9.66640457]) # old
-    c = np.array([-0.29842513, 3.55829518]) # new
-    if (log10p < -15.):
-        nsigma = np.polyval(c, log10p)    
-    if (np.isnan(nsigma)):
-        nsigma = 50.
-    
-    return nsigma
+    # p = stats.chi2.cdf(ndof, ndof*chi2r_test/chi2r_true)
+    # log10p = np.log10(max(p, 10**(-155.623))) # 50 sigma max.
+    # nsigma = np.sqrt(stats.chi2.ppf(1.-p, 1.))    
+    # c = np.array([-0.25028407, 9.66640457]) # old
+    # c = np.array([-0.29842513, 3.55829518]) # new
+    # if (log10p < -15.):
+    #     nsigma = np.polyval(c, log10p)
+    # if (np.isnan(nsigma)):
+    #     nsigma = 50.
+    # return nsigma

--- a/fouriever/uvfit.py
+++ b/fouriever/uvfit.py
@@ -354,9 +354,10 @@ class data():
                                             self.observables,
                                             cov,
                                             smear)]
-                    nsigmas += [util.nsigma(chi2r_test=thetap['fun']/ndof,
+                    nsigma, _ = util.nsigma(chi2r_test=thetap['fun']/ndof,
                                             chi2r_true=chi2s[-1]/ndof,
-                                            ndof=ndof)]
+                                            ndof=ndof)
+                    nsigmas += [nsigma]
                 else:
                     p0s += [np.array([np.nan, np.nan, np.nan])]
                     pps += [np.array([np.nan, np.nan, np.nan])]
@@ -401,9 +402,9 @@ class data():
             pe = pes[np.nanargmin(chi2s_copy)]
         sep = np.sqrt(pp[1]**2+pp[2]**2)
         pa = np.rad2deg(np.arctan2(pp[1], pp[2]))
-        nsigma = util.nsigma(chi2r_test=thetap['fun']/ndof,
-                             chi2r_true=chi2/ndof,
-                             ndof=ndof)
+        nsigma, _ = util.nsigma(chi2r_test=thetap['fun']/ndof,
+                                chi2r_true=chi2/ndof,
+                                ndof=ndof)
         
         print('   Best fit companion flux = %.3f +/- %.3f %%' % (pp[0]*100., pe[0]*100.))
         print('   Best fit companion right ascension = %.1f mas' % pp[1])
@@ -477,7 +478,8 @@ class data():
                 smear=None,
                 ofile=None,
                 searchbox=None,
-                data_list=None):
+                data_list=None,
+                use_mpmath=False):
         """
         Parameters
         ----------
@@ -504,7 +506,15 @@ class data():
             which case the data is automatically selected from the
             ``data_list`` attribute of the ``data`` class. The parameter is
             internally required by the ``systematics`` method.
-        
+        use_mpmath: bool
+            Use the ``mpmath`` module for enabling a higher precision
+            (50 decimals) on the calculated value from the CDF of the
+            chi2 distribution. If set to ``False``, the ``chi2``
+            function from ``scipy`` is used. The confidence level is
+            always calculated with ``scipy`` and has a maximum value
+            of approximately 8 sigma. The default argument is set to
+            ``False``.
+
         Returns
         -------
         fit: dict
@@ -635,7 +645,7 @@ class data():
             for j in range(len(self.observables)):
                 ndof += [np.prod(data_list[i][self.observables[j]].shape)]
         ndof = np.sum(ndof)
-        
+
         if ((model == 'ud') or (model == 'ud_bin')):
             if ('v2' not in self.observables):
                 raise UserWarning('Can only fit uniform disk with visibility amplitudes')
@@ -788,9 +798,10 @@ class data():
                     break
             
             try:
-                nsigma = util.nsigma(chi2r_test=thetap['fun']/ndof,
-                                     chi2r_true=chi2/ndof,
-                                     ndof=ndof)
+                nsigma, log_bin_prob = util.nsigma(chi2r_test=thetap['fun']/ndof,
+                                                   chi2r_true=chi2/ndof,
+                                                   ndof=ndof,
+                                                   use_mpmath=use_mpmath)
             except:
                 raise UserWarning('No local minima inside separation range or search box')
             if (model == 'bin'):
@@ -800,6 +811,7 @@ class data():
                 print('   Best fit companion separation = %.1f +/- %.1f mas' % (sep, dsep))
                 print('   Best fit companion position angle = %.1f +/- %.1f deg' % (pa, dpa))
                 print('   Best fit red. chi2 = %.3f (bin)' % (chi2/ndof))
+                print('   Log-probability of companion = %.2e' % log_bin_prob)
                 print('   Significance of companion = %.1f sigma' % nsigma)
                 fit = {}
                 fit['model'] = 'bin'
@@ -807,6 +819,7 @@ class data():
                 fit['dp'] = pe
                 fit['chi2_red'] = chi2/ndof
                 fit['ndof'] = ndof
+                fit['log_bin_prob'] = log_bin_prob
                 fit['nsigma'] = nsigma
                 fit['smear'] = smear
                 fit['cov'] = str(cov)
@@ -857,14 +870,19 @@ class data():
             fit['chi2_grid'] = chi2_grid
 
             nsigma_map = np.zeros(chi2_map.shape)
+            log_prob_map = np.zeros(chi2_map.shape)
+
             for i in range(chi2_map.shape[0]):
                 for j in range(chi2_map.shape[1]):
-                    nsigma_map[i, j] = util.nsigma(
-                        chi2r_test=thetap['fun']/ndof,
-                        chi2r_true=chi2_map[i, j]/ndof,
-                        ndof=ndof)
+                    nsigma_map[i, j], log_prob_map[i, j] = \
+                        util.nsigma(chi2r_test=thetap['fun']/ndof,
+                                    chi2r_true=chi2_map[i, j]/ndof,
+                                    ndof=ndof,
+                                    use_mpmath=use_mpmath)
 
             fit['nsigma_map'] = nsigma_map
+            fit['log_prob_map'] = log_prob_map
+            fit['chi2r_test'] = thetap['fun']/ndof
 
         return fit
     
@@ -1399,9 +1417,9 @@ class data():
                                      observables=self.observables,
                                      cov=cov,
                                      smear=smear)
-            nsigma = util.nsigma(chi2r_test=chi2_test/ndof,
-                                 chi2r_true=chi2/ndof,
-                                 ndof=ndof)
+            nsigma, _ = util.nsigma(chi2r_test=chi2_test/ndof,
+                                    chi2r_true=chi2/ndof,
+                                    ndof=ndof)
             sep = np.sqrt(pp[-2]**2+pp[-1]**2)
             pa = np.rad2deg(np.arctan2(pp[-2], pp[-1]))
             dsep = np.sqrt((pp[-2]/sep*pe[-2])**2+(pp[-1]/sep*pe[-1])**2)
@@ -1441,9 +1459,9 @@ class data():
                                      observables=self.observables,
                                      cov=cov,
                                      smear=smear)
-            nsigma = util.nsigma(chi2r_test=chi2_test/ndof,
-                                 chi2r_true=chi2/ndof,
-                                 ndof=ndof)
+            nsigma, _ = util.nsigma(chi2r_test=chi2_test/ndof,
+                                    chi2r_true=chi2/ndof,
+                                    ndof=ndof)
             sep = np.sqrt(pp[1]**2+pp[2]**2)
             pa = np.rad2deg(np.arctan2(pp[1], pp[2]))
             dsep = np.sqrt((pp[1]/sep*pe[1])**2+(pp[2]/sep*pe[2])**2)
@@ -1858,9 +1876,9 @@ class data():
                              observables=observables,
                              cov=cov,
                              smear=smear)
-            nsigma = util.nsigma(chi2r_test=chi2_test/ndof,
-                                 chi2r_true=chi2_true/ndof,
-                                 ndof=ndof)
+            nsigma, _ = util.nsigma(chi2r_test=chi2_test/ndof,
+                                    chi2r_true=chi2_true/ndof,
+                                    ndof=ndof)
             
             return np.abs(nsigma-sigma)**2
     
@@ -1939,9 +1957,9 @@ class data():
                                          observables=observables,
                                          cov=cov,
                                          smear=smear)
-            nsigma = util.nsigma(chi2r_test=chi2_ud/ndof,
-                                 chi2r_true=chi2_bin/ndof,
-                                 ndof=ndof)
+            nsigma, _ = util.nsigma(chi2r_test=chi2_ud/ndof,
+                                    chi2r_true=chi2_bin/ndof,
+                                    ndof=ndof)
             
             return np.abs(nsigma-sigma)**2
     


### PR DESCRIPTION
This PR adds the `use_mpmath` parameter to `chi2map`, which is internally used by `util.nsigma`. The reason is that the precision of `chi2.cdf` of `scipy` is insufficient for probabilities close to 1. With `mpmath` the precision of the CDF can be increased.

I have set the precision on the number of decimals to 50. The use of this function is a factor 3-4 slower than with `scipy`. The `nsigma` function returns also the log-probability of a binary detection in addition to the number of sigmas. The latter is still limited to a maximum value of ~8, since I could not find a way to implemented the quantile function (i.e. `chi2.ppf` from `scipy`) with `mpmath` (I don't think there is a closed form).

The default of `use_mpmath` is set to `False`, in which case `scipy` is used. The log-probability map is included in the returned dictionary from `chi2map` and I have also included the values of `log_bin_prob` and `chi2r_test` for convenience.