### PR TITLE
Calculate pearson rho coefficient in GRAVITY tutorial.

### DIFF
--- a/tutorials/tutorial_gravity.py
+++ b/tutorials/tutorial_gravity.py
@@ -49,8 +49,8 @@ fit = data.mcmc(fit=fit, # best fit from gridsearch
                 sampler='emcee') # sampling algorithm
 
 samples=fit['samples']
-ras=samples[:,1]
-decs=samples[:,2]
+ras=samples[:,-2]
+decs=samples[:,-1]
 print("median RA offset:",np.median(ras))
 print("median DEC offset:",np.median(decs))
 print("sigma RA offset:",np.std(ras))

--- a/tutorials/tutorial_gravity.py
+++ b/tutorials/tutorial_gravity.py
@@ -51,6 +51,7 @@ fit = data.mcmc(fit=fit, # best fit from gridsearch
 samples=fit['samples']
 ras=samples[:,-2]
 decs=samples[:,-1]
+print("valid for model='bin' and model='ud_bin':")
 print("median RA offset:",np.median(ras))
 print("median DEC offset:",np.median(decs))
 print("sigma RA offset:",np.std(ras))

--- a/tutorials/tutorial_gravity.py
+++ b/tutorials/tutorial_gravity.py
@@ -12,7 +12,7 @@ import numpy as np
 import os
 
 from fouriever import uvfit
-
+from scipy.stats import pearsonr
 
 # =============================================================================
 # MAIN
@@ -47,6 +47,15 @@ fit = data.mcmc(fit=fit, # best fit from gridsearch
                 # ofile='../figures/betaPic_90deg', # save figures
                 # ofile='../figures/HIP78183', # save figures
                 sampler='emcee') # sampling algorithm
+
+samples=fit['samples']
+ras=samples[:,1]
+decs=samples[:,2]
+print("median RA offset:",np.median(ras))
+print("median DEC offset:",np.median(decs))
+print("sigma RA offset:",np.std(ras))
+print("sigma DEC offset:",np.std(decs))
+print("pearson rho:",pearsonr(ras,decs).statistic)
 
 # Compute chi-squared map after subtracting best fit companion.
 fit_sub = data.chi2map_sub(fit_sub=fit, # best fit from MCMC


### PR DESCRIPTION
Orbital fitters such as orbitize and octofitter accept RA and DEC offsets with their covariance matrix. Where the matrix is expressed as the sigmas and a pearson rho coefficient. The exogravity code from Mathias Nowak also outputs this coefficient (see also https://arxiv.org/abs/2109.10671).

As an example I calculate these numbers based on the emcee chains in the fouriever Gravity tutorial. If necessary it can be included in the plots or printed results (e.g. uvfit.py) but this is the least intrusive way. 

scipy is already a prerequisite for fouriever.