### PR TITLE
IO enhancements

### DIFF
--- a/fouriever/average_oifits.py
+++ b/fouriever/average_oifits.py
@@ -19,8 +19,10 @@ pa_mtoc = '-'  # model to chip conversion for position angle
 
 
 def average_single(fitsfile):
-    path = fitsfile.replace('.oifits', '_avg.oifits')
 
+    fitsfile = str(fitsfile)  # In case a Path is passed
+    
+    out_path = fitsfile.replace('.oifits', '_avg.oifits')
     hdul = pyfits.open(fitsfile)
 
     oi_wavelength = pyfits.BinTableHDU.from_columns(
@@ -126,7 +128,7 @@ def average_single(fitsfile):
     hdul.append(oi_wavelength)
     hdul.append(oi_vis2)
     hdul.append(oi_t3)
-    hdul.writeto(path, output_verify='fix', overwrite=True)
+    hdul.writeto(out_path, output_verify='fix', overwrite=True)
     hdul.close()
 
-    return path
+    return out_path

--- a/fouriever/average_oifits.py
+++ b/fouriever/average_oifits.py
@@ -19,9 +19,8 @@ pa_mtoc = '-'  # model to chip conversion for position angle
 
 
 def average_single(fitsfile):
-
     fitsfile = str(fitsfile)  # In case a Path is passed
-    
+
     out_path = fitsfile.replace('.oifits', '_avg.oifits')
     hdul = pyfits.open(fitsfile)
 

--- a/fouriever/inst.py
+++ b/fouriever/inst.py
@@ -58,7 +58,9 @@ def open(idir, fitsfile, verbose=True):
         observation.
     """
 
-    hdul = pyfits.open(os.path.join(idir, fitsfile), memmap=False)
+    file_path = os.path.join(idir, fitsfile)
+
+    hdul = pyfits.open(file_path, memmap=False)
     if 'OI_TARGET' in hdul:
         inst_list, data_list = open_oifile(hdul)
     elif 'KP-DATA' in hdul:
@@ -67,7 +69,7 @@ def open(idir, fitsfile, verbose=True):
         else:
             inst_list, data_list = open_kpfile_old(hdul)
     else:
-        raise UserWarning(f'Unknown file type: {idir + fitsfile}')
+        raise UserWarning(f'Unknown file type: {file_path}')
     hdul.close()
 
     if verbose:

--- a/fouriever/intercorr.py
+++ b/fouriever/intercorr.py
@@ -8,8 +8,9 @@ from __future__ import division
 import astropy.io.fits as pyfits
 import numpy as np
 
-import glob
 import os
+
+from fouriever.util import glob_fits_files
 
 from . import inst
 
@@ -37,10 +38,7 @@ class data:
         self.fitsfiles = fitsfiles
 
         if self.fitsfiles is None:
-            self.fitsfiles = glob.glob(self.idir + '*fits')
-            for i, item in enumerate(self.fitsfiles):
-                head, tail = os.path.split(item)
-                self.fitsfiles[i] = tail
+            self.fitsfiles = glob_fits_files(self.idir)
 
         self.inst_list = []
         self.data_list = []

--- a/fouriever/intercorr.py
+++ b/fouriever/intercorr.py
@@ -123,7 +123,8 @@ class data:
         """ """
 
         for i in range(len(self.fitsfiles)):
-            hdul = pyfits.open(os.path.join(self.idir, self.fitsfiles[i]))
+            file_path = os.path.join(self.idir, self.fitsfiles[i])
+            hdul = pyfits.open(file_path)
             try:
                 hdul.pop('V2COV')
             except KeyError:
@@ -132,7 +133,7 @@ class data:
                 hdul.pop('CPCOV')
             except KeyError:
                 pass
-            hdul.writeto(os.path.join(self.idir, self.fitsfiles[i]), output_verify='fix', overwrite=True)
+            hdul.writeto(file_path, output_verify='fix', overwrite=True)
 
         pass
 
@@ -175,7 +176,7 @@ class data:
             hdu0.header['EXTNAME'] = 'V2COV'
             hdu0.header['INSNAME'] = self.inst
             hdul += [hdu0]
-            hdul.writeto(odir + self.fitsfiles[i], output_verify='fix', overwrite=True)
+            hdul.writeto(os.path.join(odir, self.fitsfiles[i]), output_verify='fix', overwrite=True)
 
         # plt.imshow(cor, origin='lower')
         # plt.xlabel('Index')
@@ -234,7 +235,7 @@ class data:
             hdu0.header['EXTNAME'] = 'CPCOV'
             hdu0.header['INSNAME'] = self.inst
             hdul += [hdu0]
-            hdul.writeto(odir + self.fitsfiles[i], output_verify='fix', overwrite=True)
+            hdul.writeto(os.path.join(odir, self.fitsfiles[i]), output_verify='fix', overwrite=True)
 
         # plt.imshow(cor, origin='lower')
         # plt.xlabel('Index')

--- a/fouriever/klcal.py
+++ b/fouriever/klcal.py
@@ -423,17 +423,9 @@ class data:
                         except Exception:
                             pass
 
-                ww = self.scifiles[i].rfind('/')
-                if ww == -1:
-                    hdul.writeto(
-                        os.path.join(odir, self.scifiles[i][:-5] + '_klcal.fits'), overwrite=True, output_verify='fix'
-                    )
-                else:
-                    hdul.writeto(
-                        os.path.join(odir, self.scifiles[i][ww + 1 : -5] + '_klcal.fits'),
-                        overwrite=True,
-                        output_verify='fix',
-                    )
+                file_stem = os.path.splitext(os.path.basename(self.scifiles[i]))[0]
+                out_path = os.path.join(odir, file_stem+'_klcal.fits')
+                hdul.writeto(out_path, overwrite=True, output_verify='fix')
                 hdul.close()
 
             elif ('OI_VIS2' in hdul) and ('OI_T3' in hdul):
@@ -526,17 +518,9 @@ class data:
                                 )
                         hdul += [hdu0, hdu1, hdu2]
 
-                ww = self.scifiles[i].rfind('/')
-                if ww == -1:
-                    hdul.writeto(
-                        os.path.join(odir, self.scifiles[i][:-7] + '_klcal.oifits'), overwrite=True, output_verify='fix'
-                    )
-                else:
-                    hdul.writeto(
-                        os.path.join(odir, self.scifiles[i][ww + 1 : -7] + '_klcal.oifits'),
-                        overwrite=True,
-                        output_verify='fix',
-                    )
+                file_stem = os.path.splitext(os.path.basename(self.scifiles[i]))[0]
+                out_path = os.path.join(odir, file_stem+'_klcal.oifits')
+                hdul.writeto(out_path, overwrite=True, output_verify='fix')
                 hdul.close()
 
             else:
@@ -643,13 +627,9 @@ class data:
                             hdul['KP-COV'].data.copy() + np.mean(kp_kpcov_cal, axis=0) / kp_kpcov_cal.shape[0]
                         )
 
-                ww = self.scifiles[i].rfind('/')
-                if ww == -1:
-                    hdul.writeto(odir + self.scifiles[i][:-5] + '_cal.fits', overwrite=True, output_verify='fix')
-                else:
-                    hdul.writeto(
-                        odir + self.scifiles[i][ww + 1 : -5] + '_cal.fits', overwrite=True, output_verify='fix'
-                    )
+                file_stem = os.path.splitext(os.path.basename(self.scifiles[i]))[0]
+                out_path = os.path.join(odir, file_stem+'_cal.fits')
+                hdul.writeto(out_path, overwrite=True, output_verify='fix')
                 hdul.close()
 
             elif ('OI_VIS2' in hdul) and ('OI_T3' in hdul):
@@ -830,17 +810,9 @@ class data:
                             hdul.pop('OI_T3')
                             hdul += [hdu_cp]
 
-                ww = self.scifiles[i].rfind('/')
-                if ww == -1:
-                    hdul.writeto(
-                        os.path.join(odir, self.scifiles[i][:-7] + '_cal.oifits'), overwrite=True, output_verify='fix'
-                    )
-                else:
-                    hdul.writeto(
-                        os.path.join(odir, self.scifiles[i][ww + 1 : -7] + '_cal.oifits'),
-                        overwrite=True,
-                        output_verify='fix',
-                    )
+                file_stem = os.path.splitext(os.path.basename(self.scifiles[i]))[0]
+                out_path = os.path.join(odir, file_stem+'_cal.oifits')
+                hdul.writeto(out_path, overwrite=True, output_verify='fix')
                 hdul.close()
 
             else:

--- a/fouriever/klcal.py
+++ b/fouriever/klcal.py
@@ -8,9 +8,10 @@ from __future__ import division
 import astropy.io.fits as pyfits
 import numpy as np
 
-import glob
 import os
 import sys
+
+from fouriever.util import glob_fits_files
 
 from . import inst
 
@@ -45,16 +46,10 @@ class data:
         self.calfiles = calfiles
 
         if self.scifiles is None:
-            self.scifiles = glob.glob(self.scidir + '*fits')
-            for i, item in enumerate(self.scifiles):
-                head, tail = os.path.split(item)
-                self.scifiles[i] = tail
+            self.scifiles = glob_fits_files(self.scidir)
 
         if self.calfiles is None:
-            self.calfiles = glob.glob(self.caldir + '*fits')
-            for i, item in enumerate(self.calfiles):
-                head, tail = os.path.split(item)
-                self.calfiles[i] = tail
+            self.calfiles = glob_fits_files(self.caldir)
 
         self.sci_inst_list = []
         self.sci_data_list = []

--- a/fouriever/klcal.py
+++ b/fouriever/klcal.py
@@ -424,7 +424,7 @@ class data:
                             pass
 
                 file_stem = os.path.splitext(os.path.basename(self.scifiles[i]))[0]
-                out_path = os.path.join(odir, file_stem+'_klcal.fits')
+                out_path = os.path.join(odir, file_stem + '_klcal.fits')
                 hdul.writeto(out_path, overwrite=True, output_verify='fix')
                 hdul.close()
 
@@ -519,7 +519,7 @@ class data:
                         hdul += [hdu0, hdu1, hdu2]
 
                 file_stem = os.path.splitext(os.path.basename(self.scifiles[i]))[0]
-                out_path = os.path.join(odir, file_stem+'_klcal.oifits')
+                out_path = os.path.join(odir, file_stem + '_klcal.oifits')
                 hdul.writeto(out_path, overwrite=True, output_verify='fix')
                 hdul.close()
 
@@ -628,7 +628,7 @@ class data:
                         )
 
                 file_stem = os.path.splitext(os.path.basename(self.scifiles[i]))[0]
-                out_path = os.path.join(odir, file_stem+'_cal.fits')
+                out_path = os.path.join(odir, file_stem + '_cal.fits')
                 hdul.writeto(out_path, overwrite=True, output_verify='fix')
                 hdul.close()
 
@@ -811,7 +811,7 @@ class data:
                             hdul += [hdu_cp]
 
                 file_stem = os.path.splitext(os.path.basename(self.scifiles[i]))[0]
-                out_path = os.path.join(odir, file_stem+'_cal.oifits')
+                out_path = os.path.join(odir, file_stem + '_cal.oifits')
                 hdul.writeto(out_path, overwrite=True, output_verify='fix')
                 hdul.close()
 

--- a/fouriever/plot.py
+++ b/fouriever/plot.py
@@ -38,6 +38,21 @@ plt.rc('figure', titlesize=18)
 # MAIN
 # =============================================================================
 
+def _save_ofile(ofile, out_id):
+    # ofile is [dir/]prefix where dir is optional
+    if (ofile is None):
+        return
+    odir, basename = os.path.split(ofile)
+    stem, ext = os.path.splitext(basename)
+    if (odir != ""):
+        os.makedirs(odir, exist_ok=True)
+    # TODO: Include dot in ext? Or remove from formats known?
+    if ("." + ext not in formats_known):
+        ext = "pdf"
+    # os.path.join will just ignore odir if it is empty
+    out_path = os.path.join(odir, stem + '_' + out_id + '.' + ext)
+    plt.savefig(out_path)
+
 
 def v2_ud_base(data_list, fit, smear=None, ofile=None):
     """
@@ -117,16 +132,7 @@ def v2_ud_base(data_list, fit, smear=None, ofile=None):
     plt.subplots_adjust(wspace=0.0, hspace=0.0)
     fig.align_ylabels()
     plt.suptitle('Uniform disk fit')
-    if ofile is not None:
-        index = ofile.rfind('/')
-        if index != -1:
-            temp = ofile[:index]
-            if not os.path.exists(temp):
-                os.makedirs(temp)
-        if ofile[-4:] in formats_known:
-            plt.savefig(ofile[:-4] + '_v2_ud' + ofile[-4:])
-        else:
-            plt.savefig(ofile + '_v2_ud.pdf')
+    _save_ofile(ofile, 'v2_ud')
     # plt.show()
     plt.close()
 
@@ -194,16 +200,7 @@ def v2_ud(data_list, fit, smear=None, ofile=None):
     plt.subplots_adjust(wspace=0.0, hspace=0.0)
     fig.align_ylabels()
     plt.suptitle('Uniform disk fit')
-    if ofile is not None:
-        index = ofile.rfind('/')
-        if index != -1:
-            temp = ofile[:index]
-            if not os.path.exists(temp):
-                os.makedirs(temp)
-        if ofile[-4:] in formats_known:
-            plt.savefig(ofile[:-4] + '_v2_ud' + ofile[-4:])
-        else:
-            plt.savefig(ofile + '_v2_ud.pdf')
+    _save_ofile(ofile, 'v2_ud')
     # plt.show()
     plt.close()
 
@@ -283,16 +280,7 @@ def cp_bin(data_list, fit, smear=None, ofile=None):
     plt.subplots_adjust(wspace=0.25, hspace=0.0)
     fig.align_ylabels()
     plt.suptitle('Point-source companion fit')
-    if ofile is not None:
-        index = ofile.rfind('/')
-        if index != -1:
-            temp = ofile[:index]
-            if not os.path.exists(temp):
-                os.makedirs(temp)
-        if ofile[-4:] in formats_known:
-            plt.savefig(ofile[:-4] + '_cp_bin' + ofile[-4:])
-        else:
-            plt.savefig(ofile + '_cp_bin.pdf')
+    _save_ofile(ofile, "cp_bin")
     # plt.show()
     plt.close()
 
@@ -415,16 +403,7 @@ def v2_cp_ud_bin(data_list, fit, smear=None, ofile=None):
     plt.subplots_adjust(wspace=1.0 / 3.0, hspace=0.0)
     fig.align_ylabels()
     plt.suptitle('Uniform disk with point-source companion fit')
-    if ofile is not None:
-        index = ofile.rfind('/')
-        if index != -1:
-            temp = ofile[:index]
-            if not os.path.exists(temp):
-                os.makedirs(temp)
-        if ofile[-4:] in formats_known:
-            plt.savefig(ofile[:-4] + '_v2_cp_ud_bin' + ofile[-4:])
-        else:
-            plt.savefig(ofile + '_v2_cp_ud_bin.pdf')
+    _save_ofile(ofile, "v2_cp_ud_bin")
     # plt.show()
     plt.close()
 
@@ -504,16 +483,7 @@ def kp_bin(data_list, fit, smear=None, ofile=None):
     plt.subplots_adjust(wspace=0.25, hspace=0.0)
     fig.align_ylabels()
     plt.suptitle('Point-source companion fit')
-    if ofile is not None:
-        index = ofile.rfind('/')
-        if index != -1:
-            temp = ofile[:index]
-            if not os.path.exists(temp):
-                os.makedirs(temp)
-        if ofile[-4:] in formats_known:
-            plt.savefig(ofile[:-4] + '_kp_bin' + ofile[-4:])
-        else:
-            plt.savefig(ofile + '_kp_bin.pdf')
+    _save_ofile(ofile, "kp_bin")
     # plt.show()
     plt.close()
 
@@ -716,16 +686,7 @@ def lincmap(
     # ax.plot(rad, max/avg, color='black', ls=':')
     # ax.set_ylabel(r'Significance [$\sigma$]', rotation=270, labelpad=20)
     plt.tight_layout()
-    if ofile is not None:
-        index = ofile.rfind('/')
-        if index != -1:
-            temp = ofile[:index]
-            if not os.path.exists(temp):
-                os.makedirs(temp)
-        if ofile[-4:] in formats_known:
-            plt.savefig(ofile[:-4] + '_lincmap' + ofile[-4:])
-        else:
-            plt.savefig(ofile + '_lincmap.pdf')
+    _save_ofile(ofile, "lincmap")
     # plt.show()
     plt.close()
 
@@ -851,16 +812,7 @@ def chi2map(pps_unique, chi2s_unique, fit, sep_range, step_size, ofile=None, sea
         plt.suptitle('Chi-squared map')
     else:
         plt.suptitle('Chi-squared map (search region shaded red)')
-    if ofile is not None:
-        index = ofile.rfind('/')
-        if index != -1:
-            temp = ofile[:index]
-            if not os.path.exists(temp):
-                os.makedirs(temp)
-        if ofile[-4:] in formats_known:
-            plt.savefig(ofile[:-4] + '_chi2map' + ofile[-4:])
-        else:
-            plt.savefig(ofile + '_chi2map.pdf')
+    _save_ofile(ofile, "chi2map")
     # plt.show()
     plt.close()
 
@@ -890,16 +842,7 @@ def chains(fit, samples, ofile=None, fixpos=False):
         plt.ylabel('$\\theta$ [mas]')
         plt.legend(loc='upper right')
         plt.suptitle('MCMC chains')
-        if ofile is not None:
-            index = ofile.rfind('/')
-            if index != -1:
-                temp = ofile[:index]
-                if not os.path.exists(temp):
-                    os.makedirs(temp)
-            if ofile[-4:] in formats_known:
-                plt.savefig(ofile[:-4] + '_mcmc_chains' + ofile[-4:])
-            else:
-                plt.savefig(ofile + '_mcmc_chains.pdf')
+        _save_ofile(ofile, "mcmc_chains")
         # plt.show()
         plt.close()
     elif (fit['model'] == 'bin'):
@@ -961,16 +904,7 @@ def chains(fit, samples, ofile=None, fixpos=False):
             plt.subplots_adjust(wspace=0.25, hspace=0.)
             fig.align_ylabels()
         plt.suptitle('MCMC chains')
-        if ofile is not None:
-            index = ofile.rfind('/')
-            if index != -1:
-                temp = ofile[:index]
-                if not os.path.exists(temp):
-                    os.makedirs(temp)
-            if ofile[-4:] in formats_known:
-                plt.savefig(ofile[:-4] + '_mcmc_chains' + ofile[-4:])
-            else:
-                plt.savefig(ofile + '_mcmc_chains.pdf')
+        _save_ofile(ofile, "mcmc_chains")
         # plt.show()
         plt.close()
     else:
@@ -1000,16 +934,7 @@ def chains(fit, samples, ofile=None, fixpos=False):
         plt.subplots_adjust(wspace=0.25, hspace=0.0)
         fig.align_ylabels()
         plt.suptitle('MCMC chains')
-        if ofile is not None:
-            index = ofile.rfind('/')
-            if index != -1:
-                temp = ofile[:index]
-                if not os.path.exists(temp):
-                    os.makedirs(temp)
-            if ofile[-4:] in formats_known:
-                plt.savefig(ofile[:-4] + '_mcmc_chains' + ofile[-4:])
-            else:
-                plt.savefig(ofile + '_mcmc_chains.pdf')
+        _save_ofile(ofile, "mcmc_chains")
         # plt.show()
         plt.close()
 
@@ -1037,16 +962,7 @@ def corner(fit, samples, ofile=None, fixpos=False):
             show_titles=True,
             title_fmt='.3f',
         )
-        if ofile is not None:
-            index = ofile.rfind('/')
-            if index != -1:
-                temp = ofile[:index]
-                if not os.path.exists(temp):
-                    os.makedirs(temp)
-            if ofile[-4:] in formats_known:
-                plt.savefig(ofile[:-4] + '_mcmc_corner' + ofile[-4:])
-            else:
-                plt.savefig(ofile + '_mcmc_corner.pdf')
+        _save_ofile(ofile, "mcmc_corner")
         # plt.show()
         plt.close()
     elif fit['model'] == 'bin':
@@ -1061,13 +977,7 @@ def corner(fit, samples, ofile=None, fixpos=False):
                 show_titles=True,
                 title_fmt='.3f',
             )
-            if ofile is not None:
-                index = ofile.rfind('/')
-                if index != -1:
-                    temp = ofile[:index]
-                    if not os.path.exists(temp):
-                        os.makedirs(temp)
-                plt.savefig(ofile + '_mcmc_corner.pdf')
+            _save_ofile(ofile, "mcmc_corner")
             # plt.show()
             plt.close()
         else:
@@ -1076,19 +986,16 @@ def corner(fit, samples, ofile=None, fixpos=False):
                 temp[:, :-2] *= 100.
                 temp[:, -2] = np.sqrt(samples[:, -2]**2+samples[:, -1]**2)
                 temp[:, -1] = np.rad2deg(np.arctan2(samples[:, -2], samples[:, -1]))
-                fig = cp.corner(temp,
-                                labels=[r'$f%.0f$ [%%]' % (i + 1) for i in range(temp.shape[1]-2)]+[r'$\rho$ [mas]', r'$\varphi$ [deg]'],
-                                titles=[r'$f%.0f$' % (i + 1) for i in range(temp.shape[1]-2)]+[r'$\rho$', r'$\varphi$'],
-                                quantiles=[0.16, 0.5, 0.84],
-                                show_titles=True,
-                                title_fmt='.3f')
-                if (ofile is not None):
-                    index = ofile.rfind('/')
-                    if index != -1:
-                        temp = ofile[:index]
-                        if not os.path.exists(temp):
-                            os.makedirs(temp)
-                    plt.savefig(ofile + '_mcmc_corner.pdf')
+                fig = cp.corner(
+                    temp,
+                    labels=[r'$f%.0f$ [%%]' % (i + 1) for i in range(temp.shape[1] - 2)]
+                    + [r'$\rho$ [mas]', r'$\varphi$ [deg]'],
+                    titles=[r'$f%.0f$' % (i + 1) for i in range(temp.shape[1] - 2)] + [r'$\rho$', r'$\varphi$'],
+                    quantiles=[0.16, 0.5, 0.84],
+                    show_titles=True,
+                    title_fmt='.3f',
+                )
+                _save_ofile(ofile, "mcmc_corner")
                 # plt.show()
                 plt.close()
             else:
@@ -1104,13 +1011,7 @@ def corner(fit, samples, ofile=None, fixpos=False):
                     show_titles=True,
                     title_fmt='.3f',
                 )
-                if ofile is not None:
-                    index = ofile.rfind('/')
-                    if index != -1:
-                        temp = ofile[:index]
-                        if not os.path.exists(temp):
-                            os.makedirs(temp)
-                    plt.savefig(ofile + '_mcmc_corner.pdf')
+                _save_ofile(ofile, "mcmc_corner")
                 # plt.show()
                 plt.close()
     else:
@@ -1126,16 +1027,7 @@ def corner(fit, samples, ofile=None, fixpos=False):
             show_titles=True,
             title_fmt='.3f',
         )
-        if ofile is not None:
-            index = ofile.rfind('/')
-            if index != -1:
-                temp = ofile[:index]
-                if not os.path.exists(temp):
-                    os.makedirs(temp)
-            if ofile[-4:] in formats_known:
-                plt.savefig(ofile[:-4] + '_mcmc_corner' + ofile[-4:])
-            else:
-                plt.savefig(ofile + '_mcmc_corner.pdf')
+        _save_ofile(ofile, "mcmc_corner")
         # plt.show()
         plt.close()
 
@@ -1206,6 +1098,7 @@ def detlim(ffs_absil, ffs_injection, sigma, sep_range, step_size, ofile=None):
     data += [rad * step_size]  # mas
     data += [-2.5 * np.log10(avg)]  # mag
     data = np.array(data)
+    # TODO: Handle with save_ofile
     if ofile is not None:
         index = ofile.rfind('/')
         if index != -1:
@@ -1223,6 +1116,7 @@ def detlim(ffs_absil, ffs_injection, sigma, sep_range, step_size, ofile=None):
     data += [rad * step_size]  # mas
     data += [-2.5 * np.log10(avg)]  # mag
     data = np.array(data)
+    # TODO: Handle with save_ofile
     if ofile is not None:
         index = ofile.rfind('/')
         if index != -1:
@@ -1259,15 +1153,6 @@ def detlim(ffs_absil, ffs_injection, sigma, sep_range, step_size, ofile=None):
     ax.legend(loc='upper right')
     plt.suptitle('Detection limits (' + str(sigma) + '-$\sigma$)')
     plt.tight_layout()
-    if ofile is not None:
-        index = ofile.rfind('/')
-        if index != -1:
-            temp = ofile[:index]
-            if not os.path.exists(temp):
-                os.makedirs(temp)
-        if ofile[-4:] in formats_known:
-            plt.savefig(ofile[:-4] + '_detlim' + ofile[-4:])
-        else:
-            plt.savefig(ofile + '_detlim.pdf')
+    _save_ofile(ofile, "detlim")
     # plt.show()
     plt.close()

--- a/fouriever/plot.py
+++ b/fouriever/plot.py
@@ -263,7 +263,7 @@ def cp_bin(data_list, fit, smear=None, ofile=None):
     plt.subplots_adjust(wspace=0.25, hspace=0.0)
     fig.align_ylabels()
     plt.suptitle('Point-source companion fit')
-    util.save_ofile(ofile, "cp_bin")
+    util.save_ofile(ofile, 'cp_bin')
     # plt.show()
     plt.close()
 
@@ -386,7 +386,7 @@ def v2_cp_ud_bin(data_list, fit, smear=None, ofile=None):
     plt.subplots_adjust(wspace=1.0 / 3.0, hspace=0.0)
     fig.align_ylabels()
     plt.suptitle('Uniform disk with point-source companion fit')
-    util.save_ofile(ofile, "v2_cp_ud_bin")
+    util.save_ofile(ofile, 'v2_cp_ud_bin')
     # plt.show()
     plt.close()
 
@@ -466,7 +466,7 @@ def kp_bin(data_list, fit, smear=None, ofile=None):
     plt.subplots_adjust(wspace=0.25, hspace=0.0)
     fig.align_ylabels()
     plt.suptitle('Point-source companion fit')
-    util.save_ofile(ofile, "kp_bin")
+    util.save_ofile(ofile, 'kp_bin')
     # plt.show()
     plt.close()
 
@@ -669,7 +669,7 @@ def lincmap(
     # ax.plot(rad, max/avg, color='black', ls=':')
     # ax.set_ylabel(r'Significance [$\sigma$]', rotation=270, labelpad=20)
     plt.tight_layout()
-    util.save_ofile(ofile, "lincmap")
+    util.save_ofile(ofile, 'lincmap')
     # plt.show()
     plt.close()
 
@@ -795,7 +795,7 @@ def chi2map(pps_unique, chi2s_unique, fit, sep_range, step_size, ofile=None, sea
         plt.suptitle('Chi-squared map')
     else:
         plt.suptitle('Chi-squared map (search region shaded red)')
-    util.save_ofile(ofile, "chi2map")
+    util.save_ofile(ofile, 'chi2map')
     # plt.show()
     plt.close()
 
@@ -825,7 +825,7 @@ def chains(fit, samples, ofile=None, fixpos=False):
         plt.ylabel('$\\theta$ [mas]')
         plt.legend(loc='upper right')
         plt.suptitle('MCMC chains')
-        util.save_ofile(ofile, "mcmc_chains")
+        util.save_ofile(ofile, 'mcmc_chains')
         # plt.show()
         plt.close()
     elif (fit['model'] == 'bin'):
@@ -887,7 +887,7 @@ def chains(fit, samples, ofile=None, fixpos=False):
             plt.subplots_adjust(wspace=0.25, hspace=0.)
             fig.align_ylabels()
         plt.suptitle('MCMC chains')
-        util.save_ofile(ofile, "mcmc_chains")
+        util.save_ofile(ofile, 'mcmc_chains')
         # plt.show()
         plt.close()
     else:
@@ -917,7 +917,7 @@ def chains(fit, samples, ofile=None, fixpos=False):
         plt.subplots_adjust(wspace=0.25, hspace=0.0)
         fig.align_ylabels()
         plt.suptitle('MCMC chains')
-        util.save_ofile(ofile, "mcmc_chains")
+        util.save_ofile(ofile, 'mcmc_chains')
         # plt.show()
         plt.close()
 
@@ -944,7 +944,7 @@ def corner(fit, samples, ofile=None, fixpos=False):
             show_titles=True,
             title_fmt='.3f',
         )
-        util.save_ofile(ofile, "mcmc_corner")
+        util.save_ofile(ofile, 'mcmc_corner')
         # plt.show()
         plt.close()
     elif fit['model'] == 'bin':
@@ -959,7 +959,7 @@ def corner(fit, samples, ofile=None, fixpos=False):
                 show_titles=True,
                 title_fmt='.3f',
             )
-            util.save_ofile(ofile, "mcmc_corner")
+            util.save_ofile(ofile, 'mcmc_corner')
             # plt.show()
             plt.close()
         else:
@@ -977,7 +977,7 @@ def corner(fit, samples, ofile=None, fixpos=False):
                     show_titles=True,
                     title_fmt='.3f',
                 )
-                util.save_ofile(ofile, "mcmc_corner")
+                util.save_ofile(ofile, 'mcmc_corner')
                 # plt.show()
                 plt.close()
             else:
@@ -993,7 +993,7 @@ def corner(fit, samples, ofile=None, fixpos=False):
                     show_titles=True,
                     title_fmt='.3f',
                 )
-                util.save_ofile(ofile, "mcmc_corner")
+                util.save_ofile(ofile, 'mcmc_corner')
                 # plt.show()
                 plt.close()
     else:
@@ -1009,7 +1009,7 @@ def corner(fit, samples, ofile=None, fixpos=False):
             show_titles=True,
             title_fmt='.3f',
         )
-        util.save_ofile(ofile, "mcmc_corner")
+        util.save_ofile(ofile, 'mcmc_corner')
         # plt.show()
         plt.close()
 
@@ -1080,7 +1080,7 @@ def detlim(ffs_absil, ffs_injection, sigma, sep_range, step_size, ofile=None):
     data += [rad * step_size]  # mas
     data += [-2.5 * np.log10(avg)]  # mag
     data = np.array(data)
-    util.save_ofile(ofile, "detlim_absil", data, out_ext="npy")
+    util.save_ofile(ofile, 'detlim_absil', data, out_ext='npy')
     rad, avg = ot.azimuthalAverage(ffs_injection, returnradii=True, binsize=1)
     ax.plot(rad * step_size, -2.5 * np.log10(avg), color=colors[1], lw=3, label='Method Injection')
     # ax.plot(rad*step_size, -2.5*np.log10(avg), color=colors[1], lw=3, ls='--', label='Method Injection (w/ cov)')
@@ -1088,7 +1088,7 @@ def detlim(ffs_absil, ffs_injection, sigma, sep_range, step_size, ofile=None):
     data += [rad * step_size]  # mas
     data += [-2.5 * np.log10(avg)]  # mag
     data = np.array(data)
-    util.save_ofile(ofile, "detlim_injection", data, out_ext="npy")
+    util.save_ofile(ofile, 'detlim_injection', data, out_ext='npy')
 
     # temp_X = np.load('/Users/jkammerer/Documents/Code/fouriever/test/Absil_X.npy')
     # temp_Y = np.load('/Users/jkammerer/Documents/Code/fouriever/test/Absil_Y.npy')
@@ -1115,6 +1115,6 @@ def detlim(ffs_absil, ffs_injection, sigma, sep_range, step_size, ofile=None):
     ax.legend(loc='upper right')
     plt.suptitle('Detection limits (' + str(sigma) + '-$\sigma$)')
     plt.tight_layout()
-    util.save_ofile(ofile, "detlim")
+    util.save_ofile(ofile, 'detlim')
     # plt.show()
     plt.close()

--- a/fouriever/plot.py
+++ b/fouriever/plot.py
@@ -48,23 +48,25 @@ def _save_ofile(ofile, out_id, out_ext=None):
     if (odir != ""):
         os.makedirs(odir, exist_ok=True)
 
-    if ext not in formats_known:
-        # If the specified extension is not valid, default to the one specified and fallback to PDF
-        out_ext = out_ext or "pdf"
-        if ext != "":
-            warnings.warn(
-                f"ofile {ofile} contains extension {ext}, but it is unknown so output extension {out_ext} will be used",
-                category=RuntimeWarning,
-                stacklevel=2
-            )
-    else:
-        # If the extension is valid and no out_ext was specified, use that extension
-        # If an out_ext was specified, it has priority, but we warn user
+    # Figure out extension:
+    # 1. If out_ext is set, it always has precedence
+    # 2. Otherwise, if ofile contains a valid extension
+    # 3. Final fallback is PDF
+    # 4. There are warnings in case of clashes
+    if ext in formats_known:
         if out_ext is None:
             out_ext = ext
         else:
             warnings.warn(
-                f"ofile {ofile} contains extension {ext}, but output extension {out_ext} will be used",
+                f"ofile {ofile} contains known extension {ext}, but output extension {out_ext} will be used",
+                category=RuntimeWarning,
+                stacklevel=2
+            )
+    else:
+        out_ext = out_ext or "pdf"
+        if ext != "":
+            warnings.warn(
+                f"ofile {ofile} contains unknown extension {ext}. Output extension {out_ext} will be used",
                 category=RuntimeWarning,
                 stacklevel=2
             )

--- a/fouriever/plot.py
+++ b/fouriever/plot.py
@@ -20,7 +20,6 @@ from . import util
 from .opticstools import opticstools as ot
 
 pa_mtoc = '-'  # model to chip conversion for position angle
-formats_known = ['pdf', 'png', 'jpg']
 
 datacol = 'mediumaquamarine'
 modelcol = 'teal'
@@ -38,47 +37,6 @@ plt.rc('figure', titlesize=18)
 # =============================================================================
 # MAIN
 # =============================================================================
-
-def _save_ofile(ofile, out_id, out_ext=None):
-    # ofile is [dir/]prefix where dir is optional
-    if (ofile is None):
-        return
-    odir, basename = os.path.split(ofile)
-    stem, ext = os.path.splitext(basename)
-    if (odir != ""):
-        os.makedirs(odir, exist_ok=True)
-
-    # Figure out extension:
-    # 1. If out_ext is set, it always has precedence
-    # 2. Otherwise, if ofile contains a valid extension
-    # 3. Final fallback is PDF
-    # 4. There are warnings in case of clashes
-    if ext in formats_known:
-        if out_ext is None:
-            out_ext = ext
-        else:
-            warnings.warn(
-                f"ofile {ofile} contains known extension {ext}, but output extension {out_ext} will be used",
-                category=RuntimeWarning,
-                stacklevel=2
-            )
-    else:
-        out_ext = out_ext or "pdf"
-        if ext != "":
-            warnings.warn(
-                f"ofile {ofile} contains unknown extension {ext}. Output extension {out_ext} will be used",
-                category=RuntimeWarning,
-                stacklevel=2
-            )
-
-    # os.path.join will just ignore odir if it is empty
-    out_path = os.path.join(odir, stem + '_' + out_id + '.' + out_ext)
-    if out_ext == "npy":
-        np.save(out_path)
-    else:
-        plt.savefig(out_path)
-
-
 def v2_ud_base(data_list, fit, smear=None, ofile=None):
     """
     Parameters
@@ -157,7 +115,7 @@ def v2_ud_base(data_list, fit, smear=None, ofile=None):
     plt.subplots_adjust(wspace=0.0, hspace=0.0)
     fig.align_ylabels()
     plt.suptitle('Uniform disk fit')
-    _save_ofile(ofile, 'v2_ud')
+    util.save_ofile(ofile, 'v2_ud')
     # plt.show()
     plt.close()
 
@@ -225,7 +183,7 @@ def v2_ud(data_list, fit, smear=None, ofile=None):
     plt.subplots_adjust(wspace=0.0, hspace=0.0)
     fig.align_ylabels()
     plt.suptitle('Uniform disk fit')
-    _save_ofile(ofile, 'v2_ud')
+    util.save_ofile(ofile, 'v2_ud')
     # plt.show()
     plt.close()
 
@@ -305,7 +263,7 @@ def cp_bin(data_list, fit, smear=None, ofile=None):
     plt.subplots_adjust(wspace=0.25, hspace=0.0)
     fig.align_ylabels()
     plt.suptitle('Point-source companion fit')
-    _save_ofile(ofile, "cp_bin")
+    util.save_ofile(ofile, "cp_bin")
     # plt.show()
     plt.close()
 
@@ -428,7 +386,7 @@ def v2_cp_ud_bin(data_list, fit, smear=None, ofile=None):
     plt.subplots_adjust(wspace=1.0 / 3.0, hspace=0.0)
     fig.align_ylabels()
     plt.suptitle('Uniform disk with point-source companion fit')
-    _save_ofile(ofile, "v2_cp_ud_bin")
+    util.save_ofile(ofile, "v2_cp_ud_bin")
     # plt.show()
     plt.close()
 
@@ -508,7 +466,7 @@ def kp_bin(data_list, fit, smear=None, ofile=None):
     plt.subplots_adjust(wspace=0.25, hspace=0.0)
     fig.align_ylabels()
     plt.suptitle('Point-source companion fit')
-    _save_ofile(ofile, "kp_bin")
+    util.save_ofile(ofile, "kp_bin")
     # plt.show()
     plt.close()
 
@@ -711,7 +669,7 @@ def lincmap(
     # ax.plot(rad, max/avg, color='black', ls=':')
     # ax.set_ylabel(r'Significance [$\sigma$]', rotation=270, labelpad=20)
     plt.tight_layout()
-    _save_ofile(ofile, "lincmap")
+    util.save_ofile(ofile, "lincmap")
     # plt.show()
     plt.close()
 
@@ -837,7 +795,7 @@ def chi2map(pps_unique, chi2s_unique, fit, sep_range, step_size, ofile=None, sea
         plt.suptitle('Chi-squared map')
     else:
         plt.suptitle('Chi-squared map (search region shaded red)')
-    _save_ofile(ofile, "chi2map")
+    util.save_ofile(ofile, "chi2map")
     # plt.show()
     plt.close()
 
@@ -867,7 +825,7 @@ def chains(fit, samples, ofile=None, fixpos=False):
         plt.ylabel('$\\theta$ [mas]')
         plt.legend(loc='upper right')
         plt.suptitle('MCMC chains')
-        _save_ofile(ofile, "mcmc_chains")
+        util.save_ofile(ofile, "mcmc_chains")
         # plt.show()
         plt.close()
     elif (fit['model'] == 'bin'):
@@ -929,7 +887,7 @@ def chains(fit, samples, ofile=None, fixpos=False):
             plt.subplots_adjust(wspace=0.25, hspace=0.)
             fig.align_ylabels()
         plt.suptitle('MCMC chains')
-        _save_ofile(ofile, "mcmc_chains")
+        util.save_ofile(ofile, "mcmc_chains")
         # plt.show()
         plt.close()
     else:
@@ -959,7 +917,7 @@ def chains(fit, samples, ofile=None, fixpos=False):
         plt.subplots_adjust(wspace=0.25, hspace=0.0)
         fig.align_ylabels()
         plt.suptitle('MCMC chains')
-        _save_ofile(ofile, "mcmc_chains")
+        util.save_ofile(ofile, "mcmc_chains")
         # plt.show()
         plt.close()
 
@@ -977,7 +935,6 @@ def corner(fit, samples, ofile=None, fixpos=False):
     fixpos: bool
         Fix position of fit?
     """
-
     if fit['model'] == 'ud':
         fig = cp.corner(
             samples,
@@ -987,7 +944,7 @@ def corner(fit, samples, ofile=None, fixpos=False):
             show_titles=True,
             title_fmt='.3f',
         )
-        _save_ofile(ofile, "mcmc_corner")
+        util.save_ofile(ofile, "mcmc_corner")
         # plt.show()
         plt.close()
     elif fit['model'] == 'bin':
@@ -1002,7 +959,7 @@ def corner(fit, samples, ofile=None, fixpos=False):
                 show_titles=True,
                 title_fmt='.3f',
             )
-            _save_ofile(ofile, "mcmc_corner")
+            util.save_ofile(ofile, "mcmc_corner")
             # plt.show()
             plt.close()
         else:
@@ -1020,7 +977,7 @@ def corner(fit, samples, ofile=None, fixpos=False):
                     show_titles=True,
                     title_fmt='.3f',
                 )
-                _save_ofile(ofile, "mcmc_corner")
+                util.save_ofile(ofile, "mcmc_corner")
                 # plt.show()
                 plt.close()
             else:
@@ -1036,7 +993,7 @@ def corner(fit, samples, ofile=None, fixpos=False):
                     show_titles=True,
                     title_fmt='.3f',
                 )
-                _save_ofile(ofile, "mcmc_corner")
+                util.save_ofile(ofile, "mcmc_corner")
                 # plt.show()
                 plt.close()
     else:
@@ -1052,7 +1009,7 @@ def corner(fit, samples, ofile=None, fixpos=False):
             show_titles=True,
             title_fmt='.3f',
         )
-        _save_ofile(ofile, "mcmc_corner")
+        util.save_ofile(ofile, "mcmc_corner")
         # plt.show()
         plt.close()
 
@@ -1123,7 +1080,8 @@ def detlim(ffs_absil, ffs_injection, sigma, sep_range, step_size, ofile=None):
     data += [rad * step_size]  # mas
     data += [-2.5 * np.log10(avg)]  # mag
     data = np.array(data)
-    _save_ofile(ofile, "detlim_absil", out_ext="npy")
+    # TODO: Add data arg
+    util.save_ofile(ofile, "detlim_absil", out_ext="npy")
     rad, avg = ot.azimuthalAverage(ffs_injection, returnradii=True, binsize=1)
     ax.plot(rad * step_size, -2.5 * np.log10(avg), color=colors[1], lw=3, label='Method Injection')
     # ax.plot(rad*step_size, -2.5*np.log10(avg), color=colors[1], lw=3, ls='--', label='Method Injection (w/ cov)')
@@ -1131,7 +1089,8 @@ def detlim(ffs_absil, ffs_injection, sigma, sep_range, step_size, ofile=None):
     data += [rad * step_size]  # mas
     data += [-2.5 * np.log10(avg)]  # mag
     data = np.array(data)
-    _save_ofile(ofile, "detlim_injection", out_ext="npy")
+    # TODO: Add data arg
+    util.save_ofile(ofile, "detlim_injection", out_ext="npy")
 
     # temp_X = np.load('/Users/jkammerer/Documents/Code/fouriever/test/Absil_X.npy')
     # temp_Y = np.load('/Users/jkammerer/Documents/Code/fouriever/test/Absil_Y.npy')
@@ -1158,6 +1117,6 @@ def detlim(ffs_absil, ffs_injection, sigma, sep_range, step_size, ofile=None):
     ax.legend(loc='upper right')
     plt.suptitle('Detection limits (' + str(sigma) + '-$\sigma$)')
     plt.tight_layout()
-    _save_ofile(ofile, "detlim")
+    util.save_ofile(ofile, "detlim")
     # plt.show()
     plt.close()

--- a/fouriever/plot.py
+++ b/fouriever/plot.py
@@ -20,7 +20,7 @@ from . import util
 from .opticstools import opticstools as ot
 
 pa_mtoc = '-'  # model to chip conversion for position angle
-formats_known = ['.pdf', '.png', '.jpg']
+formats_known = ['pdf', 'png', 'jpg']
 
 datacol = 'mediumaquamarine'
 modelcol = 'teal'
@@ -48,8 +48,7 @@ def _save_ofile(ofile, out_id, out_ext=None):
     if (odir != ""):
         os.makedirs(odir, exist_ok=True)
 
-    # TODO: Include dot in ext? Or remove from formats known?
-    if ("." + ext not in formats_known):
+    if ext not in formats_known:
         # If the specified extension is not valid, default to the one specified and fallback to PDF
         out_ext = out_ext or "pdf"
         if ext != "":

--- a/fouriever/plot.py
+++ b/fouriever/plot.py
@@ -1080,8 +1080,7 @@ def detlim(ffs_absil, ffs_injection, sigma, sep_range, step_size, ofile=None):
     data += [rad * step_size]  # mas
     data += [-2.5 * np.log10(avg)]  # mag
     data = np.array(data)
-    # TODO: Add data arg
-    util.save_ofile(ofile, "detlim_absil", out_ext="npy")
+    util.save_ofile(ofile, "detlim_absil", data, out_ext="npy")
     rad, avg = ot.azimuthalAverage(ffs_injection, returnradii=True, binsize=1)
     ax.plot(rad * step_size, -2.5 * np.log10(avg), color=colors[1], lw=3, label='Method Injection')
     # ax.plot(rad*step_size, -2.5*np.log10(avg), color=colors[1], lw=3, ls='--', label='Method Injection (w/ cov)')
@@ -1089,8 +1088,7 @@ def detlim(ffs_absil, ffs_injection, sigma, sep_range, step_size, ofile=None):
     data += [rad * step_size]  # mas
     data += [-2.5 * np.log10(avg)]  # mag
     data = np.array(data)
-    # TODO: Add data arg
-    util.save_ofile(ofile, "detlim_injection", out_ext="npy")
+    util.save_ofile(ofile, "detlim_injection", data, out_ext="npy")
 
     # temp_X = np.load('/Users/jkammerer/Documents/Code/fouriever/test/Absil_X.npy')
     # temp_Y = np.load('/Users/jkammerer/Documents/Code/fouriever/test/Absil_Y.npy')

--- a/fouriever/util.py
+++ b/fouriever/util.py
@@ -912,6 +912,7 @@ def nsigma(chi2r_test, chi2r_true, ndof, use_mpmath=False):
     #     nsigma = 50.
     # return nsigma
 
+
 def glob_fits_files(fits_dir):
     fits_files = glob.glob(os.path.join(fits_dir, '*fits'))
     for i, item in enumerate(fits_files):
@@ -921,11 +922,11 @@ def glob_fits_files(fits_dir):
 
 def save_ofile(ofile, out_id, *save_args, out_ext=None, **save_kwargs):
     # ofile is [dir/]prefix where dir is optional
-    if (ofile is None):
+    if ofile is None:
         return
     odir, basename = os.path.split(ofile)
     stem, ext = os.path.splitext(basename)
-    if (odir != ""):
+    if odir != '':
         os.makedirs(odir, exist_ok=True)
 
     # Figure out extension:
@@ -938,22 +939,22 @@ def save_ofile(ofile, out_id, *save_args, out_ext=None, **save_kwargs):
             out_ext = ext
         else:
             warnings.warn(
-                f"ofile {ofile} contains known extension {ext}, but output extension {out_ext} will be used",
+                f'ofile {ofile} contains known extension {ext}, but output extension {out_ext} will be used',
                 category=RuntimeWarning,
-                stacklevel=2
+                stacklevel=2,
             )
     else:
-        out_ext = out_ext or "pdf"
-        if ext != "":
+        out_ext = out_ext or 'pdf'
+        if ext != '':
             warnings.warn(
-                f"ofile {ofile} contains unknown extension {ext}. Output extension {out_ext} will be used",
+                f'ofile {ofile} contains unknown extension {ext}. Output extension {out_ext} will be used',
                 category=RuntimeWarning,
-                stacklevel=2
+                stacklevel=2,
             )
 
     # os.path.join will just ignore odir if it is empty
     out_path = os.path.join(odir, stem + '_' + out_id + '.' + out_ext)
-    if out_ext == "npy":
+    if out_ext == 'npy':
         np.save(out_path, *save_args, **save_kwargs)
     elif out_ext in formats_known:
         plt.savefig(out_path, *save_args, **save_kwargs)

--- a/fouriever/util.py
+++ b/fouriever/util.py
@@ -5,6 +5,8 @@ from __future__ import division
 # IMPORTS
 # =============================================================================
 
+import os
+import glob
 import warnings
 import mpmath
 import numpy as np
@@ -907,3 +909,9 @@ def nsigma(chi2r_test, chi2r_true, ndof, use_mpmath=False):
     # if (np.isnan(nsigma)):
     #     nsigma = 50.
     # return nsigma
+
+def glob_fits_files(fits_dir):
+    fits_files = glob.glob(os.path.join(fits_dir, '*fits'))
+    for i, item in enumerate(fits_files):
+        fits_files[i] = os.path.basename(item)
+    return fits_files

--- a/fouriever/util.py
+++ b/fouriever/util.py
@@ -11,9 +11,11 @@ import warnings
 import mpmath
 import numpy as np
 
+import matplotlib.pyplot as plt
 from scipy import stats
 from scipy.special import j1
 
+formats_known = ['pdf', 'png', 'jpg', 'npy']
 
 rad2mas = 180.0 / np.pi * 3600.0 * 1000.0  # convert rad to mas
 mas2rad = np.pi / 180.0 / 3600.0 / 1000.0  # convert mas to rad
@@ -915,3 +917,45 @@ def glob_fits_files(fits_dir):
     for i, item in enumerate(fits_files):
         fits_files[i] = os.path.basename(item)
     return fits_files
+
+
+def save_ofile(ofile, out_id, *save_args, out_ext=None, **save_kwargs):
+    # ofile is [dir/]prefix where dir is optional
+    if (ofile is None):
+        return
+    odir, basename = os.path.split(ofile)
+    stem, ext = os.path.splitext(basename)
+    if (odir != ""):
+        os.makedirs(odir, exist_ok=True)
+
+    # Figure out extension:
+    # 1. If out_ext is set, it always has precedence
+    # 2. Otherwise, if ofile contains a valid extension
+    # 3. Final fallback is PDF
+    # 4. There are warnings in case of clashes
+    if ext in formats_known:
+        if out_ext is None:
+            out_ext = ext
+        else:
+            warnings.warn(
+                f"ofile {ofile} contains known extension {ext}, but output extension {out_ext} will be used",
+                category=RuntimeWarning,
+                stacklevel=2
+            )
+    else:
+        out_ext = out_ext or "pdf"
+        if ext != "":
+            warnings.warn(
+                f"ofile {ofile} contains unknown extension {ext}. Output extension {out_ext} will be used",
+                category=RuntimeWarning,
+                stacklevel=2
+            )
+
+    # os.path.join will just ignore odir if it is empty
+    out_path = os.path.join(odir, stem + '_' + out_id + '.' + out_ext)
+    if out_ext == "npy":
+        np.save(out_path, *save_args, **save_kwargs)
+    elif out_ext in formats_known:
+        plt.savefig(out_path, *save_args, **save_kwargs)
+    else:
+        return out_path

--- a/fouriever/uvfit.py
+++ b/fouriever/uvfit.py
@@ -1127,21 +1127,21 @@ class data:
                 for j in range(len(self.data_list[ww[i]])):
                     v2_out += [self.data_list[ww[i]][j]['v2']]
             v2_out = np.concatenate(v2_out)
-            np.save(ofile + '_v2', v2_out)
+            util.save_ofile(ofile, "v2", v2_out, out_ext="npy")
         if 'cp' in self.observables:
             cp_out = []
             for i in range(len(ww)):
                 for j in range(len(self.data_list[ww[i]])):
                     cp_out += [self.data_list[ww[i]][j]['cp']]
             cp_out = np.concatenate(cp_out)
-            np.save(ofile + '_cp', cp_out)
+            util.save_ofile(ofile, "cp", cp_out, out_ext="npy")
         if 'kp' in self.observables:
             kp_out = []
             for i in range(len(ww)):
                 for j in range(len(self.data_list[ww[i]])):
                     kp_out += [self.data_list[ww[i]][j]['kp']]
             kp_out = np.concatenate(kp_out)
-            np.save(ofile + '_kp', kp_out)
+            util.save_ofile(ofile, "kp", kp_out, out_ext="npy")
 
         self.data_list = buffer
 
@@ -2617,6 +2617,6 @@ class data:
             plt.ylabel('$v$ (arcsec$^{-1}$)', fontsize=12.0, labelpad=0.25)
             plt.minorticks_on()
             plt.tight_layout()
-            plt.savefig(ofile + '_phase.pdf')
+            util.save_ofile(ofile, "phase")
 
         return phase_list, u_list, v_list

--- a/fouriever/uvfit.py
+++ b/fouriever/uvfit.py
@@ -452,7 +452,7 @@ class data:
             hdu3 = pyfits.ImageHDU(nsigmas)
             hdu3.header['EXTNAME'] = 'NSIGMAS'
             hdul = pyfits.HDUList([hdu0, hdu1, hdu2, hdu3])
-            out_path = util.save_ofile(ofile, "lincmap", out_ext="fits")
+            out_path = util.save_ofile(ofile, 'lincmap', out_ext='fits')
             hdul.writeto(out_path, output_verify='fix', overwrite=True)
             hdul.close()
 
@@ -1127,21 +1127,21 @@ class data:
                 for j in range(len(self.data_list[ww[i]])):
                     v2_out += [self.data_list[ww[i]][j]['v2']]
             v2_out = np.concatenate(v2_out)
-            util.save_ofile(ofile, "v2", v2_out, out_ext="npy")
+            util.save_ofile(ofile, 'v2', v2_out, out_ext='npy')
         if 'cp' in self.observables:
             cp_out = []
             for i in range(len(ww)):
                 for j in range(len(self.data_list[ww[i]])):
                     cp_out += [self.data_list[ww[i]][j]['cp']]
             cp_out = np.concatenate(cp_out)
-            util.save_ofile(ofile, "cp", cp_out, out_ext="npy")
+            util.save_ofile(ofile, 'cp', cp_out, out_ext='npy')
         if 'kp' in self.observables:
             kp_out = []
             for i in range(len(ww)):
                 for j in range(len(self.data_list[ww[i]])):
                     kp_out += [self.data_list[ww[i]][j]['kp']]
             kp_out = np.concatenate(kp_out)
-            util.save_ofile(ofile, "kp", kp_out, out_ext="npy")
+            util.save_ofile(ofile, 'kp', kp_out, out_ext='npy')
 
         self.data_list = buffer
 
@@ -2617,6 +2617,6 @@ class data:
             plt.ylabel('$v$ (arcsec$^{-1}$)', fontsize=12.0, labelpad=0.25)
             plt.minorticks_on()
             plt.tight_layout()
-            util.save_ofile(ofile, "phase")
+            util.save_ofile(ofile, 'phase')
 
         return phase_list, u_list, v_list

--- a/fouriever/uvfit.py
+++ b/fouriever/uvfit.py
@@ -1119,6 +1119,7 @@ class data:
                         - util.v2kp(vis_ref, data=self.data_list[ww[i]][j])
                     )
 
+        # TODO: Handle ofile here
         if 'v2' in self.observables:
             v2_out = []
             for i in range(len(ww)):

--- a/fouriever/uvfit.py
+++ b/fouriever/uvfit.py
@@ -48,10 +48,7 @@ class data:
         """
 
         if fitsfiles is None:
-            fitsfiles = glob.glob(idir + '*fits')
-            for i, item in enumerate(fitsfiles):
-                head, tail = os.path.split(item)
-                fitsfiles[i] = tail
+            fitsfiles = util.glob_fits_files(idir)
 
         self.inst_list = []
         self.data_list = []

--- a/fouriever/uvfit.py
+++ b/fouriever/uvfit.py
@@ -452,7 +452,8 @@ class data:
             hdu3 = pyfits.ImageHDU(nsigmas)
             hdu3.header['EXTNAME'] = 'NSIGMAS'
             hdul = pyfits.HDUList([hdu0, hdu1, hdu2, hdu3])
-            hdul.writeto(ofile + '.fits', output_verify='fix', overwrite=True)
+            out_path = util.save_ofile(ofile, "lincmap", out_ext="fits")
+            hdul.writeto(out_path, output_verify='fix', overwrite=True)
             hdul.close()
 
         return fit


### PR DESCRIPTION
This PR adds a few IO enhancements which would close #12 I think:

1. Since input `idir` and `fitsfiles` (or `scidir`/`scifiles, `caldir`/`calfiles`, etc.) are all globbed in the same way, I moved this logic to a function
2. A few `os.path.join` had already been added, but not everywhere and they were sometimes duplicated, so I tried to add more and call it only once per function when possible.
3. The output path creation in `klcal` used `rfind` to figure out the paths which can be a bit cumbersome, so I updated it to use `os.path` as much as possible.
4. The `ofile` pattern used to save files requires a bit of logic to create the full path, which was repeated in many places. I updated it and moved it to `util.save_ofile`. It is longer than the original because I added warnings to notify users when a full path with extension was used.

I expect merge conflicts between this and #20, so it is probably better to merge #20 first and I can fix conflicts here if needed.

Thank you!